### PR TITLE
Adds generator example, refactors.

### DIFF
--- a/ioredis_streaming_scan.js
+++ b/ioredis_streaming_scan.js
@@ -80,18 +80,19 @@ const ioRedisES6GeneratorSetScan = async () => {
 
   const allMembers = [];
   const setIterator = setMembersGenerator();
-  let done = false;
 
-  do {
-    let setMembers;
+  while(true) {
+    let { value, done } = await setIterator.next();
 
-    ({ value: setMembers, done } = await setIterator.next());
+    // value will be undefined when done is true, otherwise
+    // it is an array of the latest members returned from SSCAN.
 
-    // setMembers will be undefined when done is true.
-    if (! done) {
-      allMembers.push(...setMembers);
+    if (done) {
+      break;
     }
-  } while (! done);
+
+    allMembers.push(...value);
+  }
 
   return allMembers;
 };

--- a/ioredis_streaming_scan.js
+++ b/ioredis_streaming_scan.js
@@ -88,7 +88,7 @@ const ioRedisES6GeneratorSetScan = async () => {
     ({ value: setMembers, done } = await setIterator.next());
 
     // setMembers will be undefined when done is true.
-    if (setMembers) {
+    if (! done) {
       allMembers.push(...setMembers);
     }
   } while (! done);

--- a/ioredis_streaming_scan.js
+++ b/ioredis_streaming_scan.js
@@ -23,42 +23,93 @@ const createLargeSet = async () => {
 };
 
 const ioRedisRegularSetScan = async () => {
-  let it = '0';
+  let cursor = '0'; // Store cursor value from Redis.
   const allMembers = [];
 
   do {
-    const response = await redis.sscan(LARGE_SET_KEY, it);
-    // Get next value of cursor and log responses.
-    it = response[0];
-    const setMembers = response[1];
-    allMembers.push(...setMembers);
-    console.log(setMembers);
-  } while (it !== '0');
+    const response = await redis.sscan(LARGE_SET_KEY, cursor);
+    // Get next value of cursor and store values returned.
+    cursor = response[0];
+    allMembers.push(...response[1]);
+  } while (cursor !== '0');  // Done when cursor is '0' again.
 
-  console.log(`Done scanning the large set, read ${allMembers.length} members.`);
+  return allMembers;
 };
 
 const ioRedisStreamingSetScan = async () => {
-  // Read back all set members, using a scan approach (SSCAN).
-  const allMembers = [];
-  const stream = redis.sscanStream(LARGE_SET_KEY);
+  return new Promise ((resolve, reject) => {
+    try {
+      // Read back all set members, using a scan approach (SSCAN).
+      const allMembers = [];
+      const stream = redis.sscanStream(LARGE_SET_KEY);
 
-  stream.on('data', function (setMembers) {
-    // setMembers is an array of 1 or more members.
-    allMembers.push(...setMembers);
-    console.log(setMembers);
-  });
+      stream.on('data', function (setMembers) {
+        // setMembers is an array of 1 or more members.
+        allMembers.push(...setMembers);
+      });
 
-  stream.on('end', function () {
-    console.log(`Done scanning the large set, read ${allMembers.length} members.`);
-    redis.quit();
+      stream.on('end', function () {
+        // No more members left to read.
+        resolve(allMembers);
+      });
+    } catch (e) {
+      // Something went wrong :(
+      reject(e);
+    }
   });
 };
 
+const ioRedisES6GeneratorSetScan = async () => {
+  // Read back all set members, using ES6 Generator function approach.
+  const setMembersGenerator = async function* () {
+    let cursor = '0';
+
+    do {
+      const response = await redis.sscan(LARGE_SET_KEY, cursor);
+
+      // Get next value of cursor.
+      cursor = response[0];
+
+      // Yield the set members returned from Redis.
+      yield response[1];
+    } while (cursor !== '0');
+  };
+
+  // Get values from the generator.  Using the generator shields us 
+  // from the details of the Redis implementation.
+
+  const allMembers = [];
+  const setIterator = setMembersGenerator();
+  let done = false;
+
+  do {
+    let setMembers;
+
+    ({ value: setMembers, done } = await setIterator.next());
+
+    // setMembers will be undefined when done is true.
+    if (setMembers) {
+      allMembers.push(...setMembers);
+    }
+  } while (! done);
+
+  return allMembers;
+};
+
 const ioRedisLargeSetDemo = async () => {
+  console.log('Creating set...');
   await createLargeSet();
-  await ioRedisRegularSetScan();
-  await ioRedisStreamingSetScan();
+  
+  let setMembers = await ioRedisRegularSetScan();
+  console.log(`Regular scan complete, read ${setMembers.length} members.`);
+  
+  setMembers = await ioRedisStreamingSetScan();
+  console.log(`Streaming scan complete, read ${setMembers.length} members.`);
+  
+  setMembers = await ioRedisES6GeneratorSetScan();
+  console.log(`Generator scan complete, read ${setMembers.length} members.`);
+
+  redis.quit();
 };
 
 try {

--- a/ioredis_streaming_scan.js
+++ b/ioredis_streaming_scan.js
@@ -109,6 +109,8 @@ const ioRedisLargeSetDemo = async () => {
   setMembers = await ioRedisES6GeneratorSetScan();
   console.log(`Generator scan complete, read ${setMembers.length} members.`);
 
+  // Clean up
+  await redis.del(LARGE_SET_KEY);
   redis.quit();
 };
 


### PR DESCRIPTION
This adds an ES6 generator function example, to show use of `SSCAN` to retrieve all members of a set into an array in three ways with ioredis:

* `ioRedisRegularSetScan` - Using `SSCAN` and a while loop (no attempt to hide Redis internals from the developer).
* `ioRedisStreamingSetScan` - Using the streaming event based ioredis approach.
* `ioRedisGeneratorSetScan` - Using an ES6 generator function where the internals of how Redis `SSCAN` works are contained in the generator function and developer making use of it don't need to be concerned about them.

To try this:

* `npm install`
* `npm run streamingscan`

It will create one set key `large_set` in your local Redis.  This set will contain 1000 members and is deleted at the end.